### PR TITLE
Make ingnore_undocumented True

### DIFF
--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -22,7 +22,7 @@ def test_nexus_conversion(caplog, tmp_path):
         tmp_path=tmp_path,
         caplog=caplog,
     )
-    test.convert_to_nexus(caplog_level="WARNING", ignore_undocumented=False)
+    test.convert_to_nexus(caplog_level="WARNING", ignore_undocumented=True)
     test.check_reproducibility_of_nexus()
 
     caplog.clear()
@@ -34,5 +34,5 @@ def test_nexus_conversion(caplog, tmp_path):
         tmp_path=tmp_path,
         caplog=caplog,
     )
-    test.convert_to_nexus(caplog_level="WARNING", ignore_undocumented=False)
+    test.convert_to_nexus(caplog_level="WARNING", ignore_undocumented=True)
     test.check_reproducibility_of_nexus()


### PR DESCRIPTION
There is no filed 
NXraman->NXinstrument->detector_TYPE->device_information->serial_number. So getting an error:
```WARNING  pynxtools:helpers.py:118 WARNING: Field /ENTRY[entry]/INSTRUMENT[instrument]/detector_TYPE[detector_DU970BV]/FABRICATION[device_information]/serial_number written without documentation.\n'```