### PR TITLE
Fix wrong config key in nomad app

### DIFF
--- a/src/pynxtools_raman/nomad/__init__.py
+++ b/src/pynxtools_raman/nomad/__init__.py
@@ -153,7 +153,7 @@ raman_app = AppEntryPoint(
                             options=12,
                         ),
                         MenuItemTerms(
-                            name="Short Name",
+                            title="Short Name",
                             search_quantity=f"data.ENTRY.INSTRUMENT.name___short_name#{schema}",
                             width=12,
                             options=12,


### PR DESCRIPTION
The MenuItemTerms has no key "name", I assume it's meant to be "title".